### PR TITLE
修复Python3.10之前不允许在非三引号的f-string中使用换行符

### DIFF
--- a/src/application/TikTokDownloader.py
+++ b/src/application/TikTokDownloader.py
@@ -116,13 +116,10 @@ class TikTokDownloader:
             # ("Web API 模式", self.__api_object),
             # ("Web UI 模式", self.__web_ui_object),
             # ("服务器部署模式", self.__server_object),
-            (f"{self.FUNCTION_OPTIONS[self.config["Update"]]
-            }自动检查更新", self.__modify_update),
-            (f"{self.FUNCTION_OPTIONS[self.config["Record"]]
-            }作品下载记录", self.__modify_record),
+            (f"{self.FUNCTION_OPTIONS[self.config['Update']]}自动检查更新", self.__modify_update),
+            (f"{self.FUNCTION_OPTIONS[self.config['Record']]}作品下载记录", self.__modify_record),
             ("删除作品下载记录", self.delete_works_ids),
-            (f"{self.FUNCTION_OPTIONS[self.config["Logger"]]
-            }运行日志记录", self.__modify_logging),
+            (f"{self.FUNCTION_OPTIONS[self.config['Logger']]}运行日志记录", self.__modify_logging),
         )
 
     async def disable_function(self, *args, **kwargs, ):
@@ -159,8 +156,7 @@ class TikTokDownloader:
         return True
 
     def project_info(self):
-        self.console.print(f"{self.LINE}\n\n\n{self.NAME.center(
-            self.WIDTH)}\n\n\n{self.LINE}\n", style=MASTER)
+        self.console.print(f"{self.LINE}\n\n\n{self.NAME.center(self.WIDTH)}\n\n\n{self.LINE}\n", style=MASTER)
         self.console.print(f"项目地址: {REPOSITORY}", style=MASTER)
         self.console.print(f"项目文档: {DOCUMENTATION_URL}", style=MASTER)
         self.console.print(f"开源许可: {LICENCE}\n", style=MASTER)

--- a/src/application/main_complete.py
+++ b/src/application/main_complete.py
@@ -246,16 +246,7 @@ class TikTok:
 
     def __summarize_results(self, count: SimpleNamespace, name="账号"):
         time_ = time() - count.time
-        self.logger.info(
-            f"程序共处理 {
-            count.success +
-            count.failed} 个{name}，成功 {
-            count.success} 个，失败 {
-            count.failed} 个，耗时 {
-            int(time_ //
-                60)} 分钟 {
-            int(time_ %
-                60)} 秒")
+        self.logger.info(f"程序共处理{count.success + count.failed}个{name}，成功{count.success} 个，失败{count.failed}个，耗时{int(time_//60)} 分钟 {int(time_ %60)} 秒")
 
     async def account_acquisition_interactive(
             self, select="", *args, **kwargs):
@@ -494,7 +485,7 @@ class TikTok:
         self.__display_extracted_information(
             mix, id_, name, mid, title, mark, )
         addition = addition or ("合集作品" if mix else "发布作品" if post else "喜欢作品")
-        old_mark = f"{m["MARK"]}_{addition}" if (
+        old_mark = f"{m['MARK']}_{addition}" if (
             m := await self.cache.has_cache(
                 mid if mix else id_)) else None
         async with logger(root,
@@ -885,7 +876,7 @@ class TikTok:
             select = choose("请选择合集链接来源",
                             [i[0] for i in function], self.console)
         await self.__multiple_choice(select, function, root, params, logger, )
-        self.logger.info(f"已退出批量下载合集作品{"(TikTok)" if tiktok else "(抖音)"}模式")
+        self.logger.info(f"已退出批量下载合集作品{'(TikTok)' if tiktok else '(抖音)'}模式")
 
     async def __multiple_choice(self, select: str, function, *args, **kwargs, ):
         if select.upper() == "Q":
@@ -1008,9 +999,7 @@ class TikTok:
                 continue
             mix_id, id_ = await self._check_mix_id(data.url)
             if not id_:
-                self.logger.warning(
-                    f"配置文件 mix_urls 参数" f"第 {index} 条数据的 url {
-                    data.url} 错误，获取作品 ID 或合集 ID 失败")
+                self.logger.warning(f"配置文件mix_urls参数, 第{index}条数据的url{data.url}错误，获取作品ID或合集ID失败")
                 count.failed += 1
                 continue
             if not await self._deal_mix_detail(
@@ -1037,9 +1026,7 @@ class TikTok:
                 continue
             _, ids, title = await self.links_tiktok.run(data.url, type_="mix")
             if not ids:
-                self.logger.warning(
-                    f"配置文件 mix_urls_tiktok 参数" f"第 {index} 条数据的 url {
-                    data.url} 错误，获取合集 ID 失败")
+                self.logger.warning(f"配置文件mix_urls_tiktok参数, 第{index}条数据的url{data.url}错误，获取合集ID失败")
                 count.failed += 1
                 continue
             id_, title = ids[0], title[0]
@@ -1344,12 +1331,7 @@ class TikTok:
             start = time()
             await self._deal_collection_data(root, params, logger, sec_user_id)
             time_ = time() - start
-            self.logger.info(
-                f"程序运行耗时 {
-                int(time_ //
-                    60)} 分钟 {
-                int(time_ %
-                    60)} 秒")
+            self.logger.info(f"程序运行耗时 {int(time_ //60)} 分钟 {int(time_ %60)} 秒")
         self.logger.info("已退出批量下载收藏作品(抖音)模式")
 
     @check_cookie_state(tiktok=False)
@@ -1364,12 +1346,7 @@ class TikTok:
             for i, j in zip(names, ids):
                 await self._deal_collects_data(root, params, logger, sec_user_id, i, j)
             time_ = time() - start
-            self.logger.info(
-                f"程序运行耗时 {
-                int(time_ //
-                    60)} 分钟 {
-                int(time_ %
-                    60)} 秒")
+            self.logger.info(f"程序运行耗时 {int(time_ //60)} 分钟 {int(time_ %60)} 秒")
         else:
             self.console.print("该模式必须设置 owner_url 参数才能使用", style=WARNING)
         self.logger.info("已退出批量下载收藏夹作品(抖音)模式")
@@ -1407,12 +1384,7 @@ class TikTok:
             data = await self.extractor.run(data, None, "music", )
             await self.downloader.run_music(data, )
         time_ = time() - start
-        self.logger.info(
-            f"程序运行耗时 {
-            int(time_ //
-                60)} 分钟 {
-            int(time_ %
-                60)} 秒")
+        self.logger.info(f"程序运行耗时 {int(time_ //60)} 分钟 {int(time_ %60)} 秒")
         self.logger.info("已退出批量下载收藏音乐(抖音)模式")
 
     async def __handle_collection_music(self,

--- a/src/application/main_web_UI.py
+++ b/src/application/main_web_UI.py
@@ -93,10 +93,10 @@ class WebUI(TikTok):
     @staticmethod
     def generate_live_data(data: dict) -> dict:
         return {
-            "text": "\n".join((f"直播标题: {data["title"]}",
-                               f"主播昵称: {data["nickname"]}",
-                               f"在线观众: {data["user_count_str"]}",
-                               f"观看次数: {data["total_user_str"]}",)),
+            "text": "\n".join((f"直播标题: {data['title']}",
+                               f"主播昵称: {data['nickname']}",
+                               f"在线观众: {data['user_count_str']}",
+                               f"观看次数: {data['total_user_str']}",)),
             "flv": data["flv_pull_url"],
             "m3u8": data["hls_pull_url_map"],
             "best": list(data["flv_pull_url"].values())[0],

--- a/src/config/parameter.py
+++ b/src/config/parameter.py
@@ -258,7 +258,7 @@ class Parameter:
                 await TtWidTikTok.get_tt_wid(
                     self.logger,
                     self.headers_params_tiktok,
-                    self.twc_tiktok or f"{TtWidTikTok.NAME}={cookie.get(TtWidTikTok.NAME, "")}",
+                    self.twc_tiktok or f"{TtWidTikTok.NAME}={cookie.get(TtWidTikTok.NAME, '')}",
                     **self.proxy_tiktok,
                 ),
             )

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -155,9 +155,7 @@ class Settings:
         data_keys = set(data.keys())
         if not (miss := default_keys - data_keys):
             return data
-        if self.console.input(
-                f"配置文件 settings.json 缺少 {"、".join(miss)} 参数，是否需要生成默认配置文件(YES/NO): ",
-                style=ERROR).upper() == "YES":
+        if self.console.input(f"配置文件settings.json缺少{'、'.join(miss)}参数，是否需要生成默认配置文件(YES/NO): ", style=ERROR).upper() == "YES":
             self.__create()
         self.console.print("本次运行将会使用各项参数默认值，程序功能可能无法正常使用！", style=WARNING)
         return self.default

--- a/src/custom/internal.py
+++ b/src/custom/internal.py
@@ -29,8 +29,7 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 VERSION_MAJOR = 5
 VERSION_MINOR = 4
 VERSION_BETA = False
-PROJECT_NAME = f"TikTokDownloader V{VERSION_MAJOR}.{
-VERSION_MINOR}{" Beta" if VERSION_BETA else ""}"
+PROJECT_NAME = f"TikTokDownloader V{VERSION_MAJOR}.{VERSION_MINOR}{' Beta' if VERSION_BETA else ''}"
 
 REPOSITORY = "https://github.com/JoeanAmier/TikTokDownloader"
 LICENCE = "GNU General Public License v3.0"

--- a/src/downloader/download.py
+++ b/src/downloader/download.py
@@ -208,12 +208,7 @@ class Downloader:
             self, data: list[tuple], tasks: list, commands: list):
         for i, f, m in data:
             name = self.cleaner.filter_name(
-                f'{
-                i["title"]}{
-                self.split}{
-                i["nickname"]}{
-                self.split}{
-                datetime.now():%Y-%m-%d %H.%M.%S}.flv',
+                f'{i["title"]}{self.split}{i["nickname"]}{self.split}{datetime.now():%Y-%m-%d %H.%M.%S}.flv',
                 inquire=False,
                 default=str(
                     time())[

--- a/src/extract/extractor.py
+++ b/src/extract/extractor.py
@@ -809,8 +809,7 @@ class Extractor:
             data, "custom_verify", "无")
         container.cache["enterprise"] = self.safe_extract(
             data, "enterprise_verify_reason", "无")
-        container.cache["url"] = f"https: // www.douyin.com / user / {
-        container.cache["sec_uid"]}"
+        container.cache["url"] = f"https: // www.douyin.com / user / {container.cache['sec_uid']}"
         container.all_data.append(container.cache)
 
     async def __search(

--- a/src/interface/info.py
+++ b/src/interface/info.py
@@ -51,5 +51,5 @@ class Info(API):
     def __generate_data(self, ) -> dict:
         if isinstance(self.sec_user_id, str):
             self.sec_user_id = [self.sec_user_id]
-        value = f"[{",".join(f'"{i}"' for i in self.sec_user_id)}]"
+        value = f"[{','.join(f'{i}' for i in self.sec_user_id)}]"
         return {"sec_user_ids": value, }

--- a/src/manager/cache.py
+++ b/src/manager/cache.py
@@ -39,7 +39,7 @@ class Cache:
             self.__check_file(solo_mode, type_, id_, mark, name, addition, d, )
         data = (id_, name, mark)
         await self.database.update_mapping_data(*data)
-        self.log.info(f"更新缓存数据: {", ".join(data)}", False)
+        self.log.info(f"更新缓存数据: {', '.join(data)}", False)
 
     async def has_cache(self, id_: str) -> dict:
         return await self.database.read_mapping_data(id_)
@@ -56,8 +56,7 @@ class Cache:
     ):
         if not (
                 old_folder := self.root.joinpath(
-                    f"{type_}{id_}_{
-                    data["mark"] or data["name"]}_{addition}")).is_dir():
+                    f"{type_}{id_}_{data['mark'] or data['name']}_{addition}")).is_dir():
             self.log.info(f"{old_folder} 文件夹不存在，自动跳过", False)
             return
         if data["mark"] != mark:

--- a/src/manager/recorder.py
+++ b/src/manager/recorder.py
@@ -85,8 +85,7 @@ class __DownloadRecorder:
         if self.state:
             return ids
         self.console.print(
-            f"程序检测到上次运行可能没有正常结束，您的作品下载记录数据可能已经丢失！\n数据文件路径：{
-            self.path.resolve()}", style=ERROR)
+            f"程序检测到上次运行可能没有正常结束，您的作品下载记录数据可能已经丢失！\n数据文件路径：{self.path.resolve()}", style=ERROR)
         if self.backup.exists():
             if self.console.input(
                     "检测到 IDRecorder 备份文件，是否恢复最后一次备份的数据(YES/NO): ",

--- a/src/record/logger.py
+++ b/src/record/logger.py
@@ -39,9 +39,7 @@ class LoggerManager(BaseLogger):
             dir_.mkdir()
         file_handler = FileHandler(
             dir_.joinpath(
-                f"{filename}.log" if filename else f"{strftime(
-                    self._name,
-                    localtime())}.log"),
+                f"{filename}.log" if filename else f"{strftime(self._name,localtime())}.log"),
             encoding=self.encode)
         formatter = Formatter(format_, datefmt="%Y-%m-%d %H:%M:%S")
         file_handler.setFormatter(formatter)


### PR DESCRIPTION
同时修改了f-string也不要出现双引号套用双引号的情况。在 Python 中，f-strings（格式化字符串字面量）允许你在大括号 {} 内包含表达式。然而，在 Python 3.10 及更早版本中，你不能在非三引号的 f-string 的表达式部分使用换行符。这意味着除非使用三引号，否则不能在 f-string 的大括号内将表达式分成多行。