### PR TITLE
fix: 1. 解决sqlite修改表名错误问题; 2. 解决打印错误抛出的异常

### DIFF
--- a/src/storage/sqlite.py
+++ b/src/storage/sqlite.py
@@ -73,7 +73,7 @@ class SQLLogger(BaseSQLLogger):
         old_sheet = "_".join(mark)
         if await self.__check_sheet_exists(old_sheet):
             try:
-                await self.cursor.execute(self.UPDATE_SQL, (old_sheet, new_sheet))
+                await self.cursor.execute(f'ALTER TABLE {old_sheet} RENAME TO {new_sheet}')
             except OperationalError as e:
                 print(
                     Text(
@@ -82,7 +82,7 @@ class SQLLogger(BaseSQLLogger):
                                 _(
                                     "更新数据表名称时发生错误，重命名失败，请向作者反馈以便修复问题！"
                                 ),
-                                e,
+                                str(e),
                                 old_sheet,
                                 new_sheet,
                             )


### PR DESCRIPTION
1. 曾经下载过的博主，修改了昵称，更新表名时sqlite的语法有些差异，他不支持?占位符，改成了不带占位符的方式不再报错
2. except捕获异常后，打印信息时 e 并未自动转为字符串，join时再次出现异常，导致卡住，改成了转成字符串后不再报错

## Summary by Sourcery

修复 SQLite 表重命名失败的问题，并在重命名操作期间记录异常时防止产生次要错误。

错误修复：
- 调整 SQLite 表重命名逻辑，使用直接的 `ALTER TABLE` 语句而不使用参数占位符，以避免在某些 SQLite 版本上出现 `OperationalError`。
- 在将捕获到的异常拼接为错误消息之前，先将其转换为字符串，以防止在日志记录过程中产生额外的异常。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SQLite table rename failures and prevent secondary errors when logging exceptions during rename operations.

Bug Fixes:
- Adjust SQLite table rename to use direct ALTER TABLE syntax without parameter placeholders to avoid OperationalError on some SQLite versions.
- Convert caught exceptions to strings before joining into error messages to prevent additional exceptions during logging.

</details>