### PR TITLE
fix: 解决sqlite修改表名异常问题

### DIFF
--- a/src/storage/sql.py
+++ b/src/storage/sql.py
@@ -9,4 +9,4 @@ __all__ = ["BaseSQLLogger"]
 class BaseSQLLogger(BaseTextLogger):
     SHEET_NAME: Pattern = compile(r"[^\u4e00-\u9fffa-zA-Z0-9_]")
     CHECK_SQL = "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?;"
-    UPDATE_SQL = "ALTER TABLE ? RENAME TO ?;"
+    UPDATE_SQL = "ALTER TABLE {old_name} RENAME TO {new_name};"

--- a/src/storage/sqlite.py
+++ b/src/storage/sqlite.py
@@ -73,7 +73,7 @@ class SQLLogger(BaseSQLLogger):
         old_sheet = "_".join(mark)
         if await self.__check_sheet_exists(old_sheet):
             try:
-                await self.cursor.execute(self.UPDATE_SQL, (old_sheet, new_sheet))
+                await self.cursor.execute(self.UPDATE_SQL.format(old_name=old_sheet, new_name=new_sheet))
             except OperationalError as e:
                 print(
                     Text(
@@ -82,7 +82,7 @@ class SQLLogger(BaseSQLLogger):
                                 _(
                                     "更新数据表名称时发生错误，重命名失败，请向作者反馈以便修复问题！"
                                 ),
-                                e,
+                                str(e),
                                 old_sheet,
                                 new_sheet,
                             )


### PR DESCRIPTION
fix: 解决sqlite修改表名异常问题

## Summary by Sourcery

修复 SQLite 表重命名的处理逻辑，以便在更新工作表名称时，能够正确构建并执行 `ALTER TABLE` 语句。

Bug 修复：
- 通过在 `ALTER TABLE` 语句中使用明确的旧表名和新表名，而不是使用参数占位符，解决重命名 SQLite 表时出现的失败问题。

增强功能：
- 当表重命名失败时，通过在显示前将 `OperationalError` 转换为字符串来改进错误日志记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SQLite table rename handling to correctly construct and execute the ALTER TABLE statement when updating sheet names.

Bug Fixes:
- Resolve failures when renaming SQLite tables by formatting the ALTER TABLE statement with explicit old and new table names instead of using parameter placeholders.

Enhancements:
- Improve error logging when table rename fails by converting the OperationalError to a string before displaying it.

</details>