### PR TITLE
fix: preprocessing_data crash for favorite/collection API mode

### DIFF
--- a/src/application/main_terminal.py
+++ b/src/application/main_terminal.py
@@ -557,7 +557,7 @@ class TikTok:
             if index
             else _("开始处理账号")
         )
-        if api:
+        if api and tab not in {"favorite", "collection"}:
             info = None
         elif not (
             info := await self.get_user_info_data(

--- a/src/extract/extractor.py
+++ b/src/extract/extractor.py
@@ -897,29 +897,32 @@ class Extractor:
                     return id_, name, mark
                 case "favorite" | "collection":
                     try:
+                        params = (
+                            self.extract_params_tiktok
+                            if tiktok
+                            else self.extract_params
+                        )
                         item = self.__select_item(
                             data,
                             user_id,
-                            (self.extract_params_tiktok if tiktok else self.extract_params)[
-                                "sec_uid"
-                            ],
+                            params["sec_uid"],
                         )
                         id_, name, mark = self.__extract_pretreatment_data(
                             item,
-                            (self.extract_params_tiktok if tiktok else self.extract_params)[
-                                "uid"
-                            ],
-                            (self.extract_params_tiktok if tiktok else self.extract_params)[
-                                "nickname"
-                            ],
+                            params["uid"],
+                            params["nickname"],
                             mark,
                         )
                         return id_, name, mark
-                    except DownloaderError:
+                    except DownloaderError as e:
+                        self.log.warning(
+                            _("fallback user info: {error}").format(error=e),
+                        )
+                        name = self.cleaner.filter_name(mark, user_id)
                         return (
                             user_id,
-                            self.cleaner.filter_name(mark, user_id),
-                            self.cleaner.filter_name(mark, user_id),
+                            name,
+                            self.cleaner.filter_name(mark, name),
                         )
                 case "mix":
                     if tiktok:

--- a/src/extract/extractor.py
+++ b/src/extract/extractor.py
@@ -895,6 +895,32 @@ class Extractor:
                         mark,
                     )
                     return id_, name, mark
+                case "favorite" | "collection":
+                    try:
+                        item = self.__select_item(
+                            data,
+                            user_id,
+                            (self.extract_params_tiktok if tiktok else self.extract_params)[
+                                "sec_uid"
+                            ],
+                        )
+                        id_, name, mark = self.__extract_pretreatment_data(
+                            item,
+                            (self.extract_params_tiktok if tiktok else self.extract_params)[
+                                "uid"
+                            ],
+                            (self.extract_params_tiktok if tiktok else self.extract_params)[
+                                "nickname"
+                            ],
+                            mark,
+                        )
+                        return id_, name, mark
+                    except DownloaderError:
+                        return (
+                            user_id,
+                            self.cleaner.filter_name(mark, user_id),
+                            self.cleaner.filter_name(mark, user_id),
+                        )
                 case "mix":
                     if tiktok:
                         id_ = mix_id


### PR DESCRIPTION
**Bug**: When calling \`/douyin/account\` API with \`tab=favorite\` or \`tab=collection\`, the endpoint crashes with \`DownloaderError: 提取账号信息或合集信息失败\`.

**Root Cause**: 
1. API mode skips user info lookup (\`info = None\`), causing \`preprocessing_data\` to fall through to the \`list\` branch which tries to match \`sec_uid\` from video data.
2. For \`favorite\`/`collection` modes, video authors are original creators, not the target user — \`sec_uid\` never matches.

**Fix**:
- \`extractor.py\`: Split \`post\` from \`favorite\`/`collection` in \`preprocessing_data\`. Add try/except fallback so when video data can't be matched, gracefully return \`user_id\` + \`mark\`.
- \`main_terminal.py\`: \`favorite\`/`collection` modes always query user info even in API mode, ensuring accurate metadata.

## Summary by Sourcery

在预处理和 API 流程中正确处理“收藏”和“合集”账号模式，以避免崩溃并确保用户元数据可用。

Bug 修复：
- 通过添加专门的预处理逻辑，并在无法匹配视频数据时提供安全回退，防止在处理“收藏”或“合集”标签页时发生崩溃。
- 确保在 API 模式下，“收藏”和“合集”标签页仍然会获取用户信息，从而保持账号元数据的准确性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle favorite and collection account modes correctly in preprocessing and API flows to avoid crashes and ensure user metadata is available.

Bug Fixes:
- Prevent crashes when processing favorite or collection tabs by adding dedicated preprocessing logic and a safe fallback when video data cannot be matched.
- Ensure favorite and collection tabs in API mode still fetch user info so account metadata remains accurate.

</details>