### PR TITLE
feat: add CLI entry for "批量下载喜欢作品(抖音)"

### DIFF
--- a/src/application/main_terminal.py
+++ b/src/application/main_terminal.py
@@ -2287,7 +2287,7 @@ class TikTok:
             pages=pages,
         )
         if not any(account_data):
-            return None
+            return
         if source:
             return self.extractor.source_date_filter(
                 account_data,

--- a/src/application/main_terminal.py
+++ b/src/application/main_terminal.py
@@ -171,6 +171,10 @@ class TikTok:
                 _("采集抖音热榜数据(抖音)"),
                 self.hot_interactive,
             ),
+            (
+                _("批量下载喜欢作品(抖音)"),
+                self.favorite_interactive,
+            ),
             # (_("批量下载话题作品(抖音)"),),
             (
                 _("批量下载收藏作品(抖音)"),
@@ -2070,6 +2074,19 @@ class TikTok:
         return time_, data
 
     @check_cookie_state(tiktok=False)
+    async def favorite_interactive(
+        self,
+        *args,
+    ):
+        if sec_user_id := await self.__check_owner_url():
+            start = time()
+            await self._deal_favorite_data(
+                sec_user_id,
+            )
+            self._time_statistics(start)
+        self.logger.info(_("已退出批量下载喜欢作品(抖音)模式"))
+
+    @check_cookie_state(tiktok=False)
     async def collection_interactive(
         self,
         *args,
@@ -2232,6 +2249,59 @@ class TikTok:
             api,
             tiktok=tiktok,
             mode="collection",
+            mark=self.owner.mark,
+            user_id=sec_user_id,
+            info=info,
+        )
+
+    async def _deal_favorite_data(
+        self,
+        sec_user_id: str,
+        api=False,
+        source=False,
+        cookie: str = None,
+        proxy: str = None,
+        pages: int = None,
+        tiktok=False,
+    ):
+        self.logger.info(_("开始获取喜欢作品数据"))
+        if not (
+            info := await self.get_user_info_data(
+                tiktok,
+                cookie,
+                proxy,
+                sec_user_id=sec_user_id,
+            )
+        ):
+            self.logger.warning(
+                _("{sec_user_id} 获取账号信息失败").format(sec_user_id=sec_user_id)
+            )
+            return
+        account_data, earliest, latest = await self._get_account_data(
+            cookie=cookie,
+            proxy=proxy,
+            sec_user_id=sec_user_id,
+            tab="favorite",
+            earliest="",
+            latest="",
+            pages=pages,
+        )
+        if not any(account_data):
+            return None
+        if source:
+            return self.extractor.source_date_filter(
+                account_data,
+                earliest,
+                latest,
+                tiktok,
+            )
+        await self._batch_process_detail(
+            account_data,
+            api,
+            earliest=earliest,
+            latest=latest,
+            tiktok=tiktok,
+            mode="favorite",
             mark=self.owner.mark,
             user_id=sec_user_id,
             info=info,


### PR DESCRIPTION
**Feature**: Add CLI menu option to download a user's liked/favorited works (喜欢作品).

The backend already supports \`tab=favorite\` via the API, but the CLI menu had no entry for it. This PR adds the interactive entry point alongside existing "收藏作品" and "收藏夹作品" options.

**Changes**:
- Add "批量下载喜欢作品(抖音)" to the main CLI menu
- Add \`favorite_interactive()\` method
- Add \`_deal_favorite_data()\` method (mirrors \`_deal_collection_data()\` pattern)

## Summary by Sourcery

在现有合集下载选项的基础上，新增一个 CLI 入口和工作流程，用于批量下载抖音用户的点赞作品。

新功能：
- 在 CLI 主菜单中新增一个选项，用于批量下载抖音用户的点赞（收藏）作品。
- 引入一个交互式工作流程，引导用户从指定账号发起点赞作品下载。
- 新增后端处理逻辑，使用现有账号数据流水线，并通过专用的“favorite”模式来获取和处理点赞作品数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new CLI entry and workflow to download a Douyin user's liked works in batch alongside existing collection-download options.

New Features:
- Expose a new main menu option in the CLI for batch downloading a Douyin user's liked (favorite) works.
- Introduce an interactive workflow to guide users through initiating liked-works downloads from a specified account.
- Add backend handling to fetch and process liked-works data using the existing account data pipeline with a dedicated favorite mode.

</details>