### PR TITLE
fix(downloader): prevent static and dynamic cover collisions

### DIFF
--- a/src/downloader/download.py
+++ b/src/downloader/download.py
@@ -532,10 +532,15 @@ class Downloader:
         dynamic_suffix: str = "webp",
         **kwargs,
     ) -> None:
+        static_url = item["static_cover"]
+        dynamic_url = item["dynamic_cover"]
+        both_covers = all(
+            (self.static_cover, static_url, self.dynamic_cover, dynamic_url)
+        )
         if all(
             (
                 self.static_cover,
-                url := item["static_cover"],
+                static_url,
                 not self.is_exists(
                     p := actual_root.with_name(f"{name}.{static_suffix}")
                 ),
@@ -543,7 +548,7 @@ class Downloader:
         ):
             tasks.append(
                 (
-                    url,
+                    static_url,
                     temp_root.with_name(f"{name}.{static_suffix}"),
                     p,
                     f"【封面】{name}",
@@ -551,20 +556,35 @@ class Downloader:
                     static_suffix,
                 )
             )
+        # A bare WebP can be a legacy dynamic cover or a static cover normalized
+        # to WebP. There is no source metadata, so preserve the legacy behavior.
+        legacy_dynamic = actual_root.with_name(f"{name}.{dynamic_suffix}")
+        typed_dynamic = actual_root.with_name(f"{name}_dynamic.{dynamic_suffix}")
+        normalized_dynamic_exists = any(
+            self.is_exists(typed_dynamic.with_suffix(f".{suffix}"))
+            for content_type, suffix in self.CONTENT_TYPE_MAP.items()
+            if content_type.startswith("image/")
+        )
+        dynamic_exists = any(
+            (
+                self.is_exists(legacy_dynamic),
+                self.is_exists(typed_dynamic),
+                normalized_dynamic_exists,
+            )
+        )
+        dynamic_path = typed_dynamic if both_covers else legacy_dynamic
         if all(
             (
                 self.dynamic_cover,
-                url := item["dynamic_cover"],
-                not self.is_exists(
-                    p := actual_root.with_name(f"{name}.{dynamic_suffix}")
-                ),
+                dynamic_url,
+                not dynamic_exists,
             )
         ):
             tasks.append(
                 (
-                    url,
-                    temp_root.with_name(f"{name}.{dynamic_suffix}"),
-                    p,
+                    dynamic_url,
+                    temp_root.with_name(dynamic_path.name),
+                    dynamic_path,
                     f"【动图】{name}",
                     id_,
                     dynamic_suffix,

--- a/src/testers/test_download.py
+++ b/src/testers/test_download.py
@@ -1,0 +1,162 @@
+from asyncio import Event, Semaphore, run, wait_for
+from types import SimpleNamespace
+
+from httpx import AsyncClient, MockTransport, Response
+from pytest import mark
+
+from src.downloader import Downloader
+from src.tools import FakeProgress
+
+
+class Recorder:
+    async def update_id(self, id_):
+        pass
+
+    async def delete_id(self, id_):
+        pass
+
+
+def create_downloader(static_cover: bool, dynamic_cover: bool) -> Downloader:
+    downloader = Downloader.__new__(Downloader)
+    downloader.static_cover = static_cover
+    downloader.dynamic_cover = dynamic_cover
+    downloader.headers = {}
+    downloader.headers_tiktok = {}
+    downloader.log = SimpleNamespace(
+        info=lambda *args: None,
+        warning=lambda *args: None,
+        error=lambda *args: None,
+    )
+    downloader.console = SimpleNamespace(warning=lambda *args: None)
+    downloader.chunk = 1024
+    downloader.max_retry = 0
+    downloader.max_size = 0
+    downloader.recorder = Recorder()
+    downloader.truncate = 80
+    return downloader
+
+
+@mark.parametrize(
+    ("static_cover", "dynamic_cover", "expected"),
+    [
+        (True, False, "work.jpeg"),
+        (False, True, "work.webp"),
+    ],
+)
+def test_download_cover_preserves_single_cover_names(
+    tmp_path, static_cover, dynamic_cover, expected
+):
+    downloader = create_downloader(static_cover, dynamic_cover)
+    tasks = []
+
+    downloader.download_cover(
+        tasks,
+        "work",
+        "1",
+        {
+            "static_cover": "https://example.com/static",
+            "dynamic_cover": "https://example.com/dynamic",
+        },
+        tmp_path.joinpath("cache", "work"),
+        tmp_path.joinpath("output", "work"),
+    )
+
+    assert len(tasks) == 1
+    assert tasks[0][2].name == expected
+
+
+def test_download_cover_treats_ambiguous_webp_as_legacy_dynamic(tmp_path):
+    downloader = create_downloader(True, True)
+    output = tmp_path.joinpath("output")
+    output.mkdir()
+    output.joinpath("work.webp").write_bytes(
+        b"RIFF\x0c\x00\x00\x00WEBPVP8 \x00\x00\x00\x00"
+    )
+    tasks = []
+
+    downloader.download_cover(
+        tasks,
+        "work",
+        "1",
+        {
+            "static_cover": "https://example.com/static",
+            "dynamic_cover": "https://example.com/dynamic",
+        },
+        tmp_path.joinpath("cache", "work"),
+        output.joinpath("work"),
+    )
+
+    assert len(tasks) == 1
+    assert tasks[0][2].name == "work.jpeg"
+
+
+def test_concurrent_jpeg_covers_use_distinct_files(tmp_path):
+    async def download_covers():
+        started = 0
+        both_started = Event()
+
+        async def handler(request):
+            nonlocal started
+            started += 1
+            if started == 2:
+                both_started.set()
+            await wait_for(both_started.wait(), 1)
+            content = b"static" if request.url.path == "/static" else b"dynamic"
+            return Response(
+                200,
+                headers={
+                    "Content-Type": "image/jpeg",
+                    "Content-Length": str(len(content)),
+                },
+                content=content,
+            )
+
+        cache = tmp_path.joinpath("cache")
+        output = tmp_path.joinpath("output")
+        cache.mkdir()
+        output.mkdir()
+        downloader = create_downloader(True, True)
+        item = {
+            "static_cover": "https://example.com/static",
+            "dynamic_cover": "https://example.com/dynamic",
+        }
+        tasks = []
+        async with AsyncClient(transport=MockTransport(handler)) as client:
+            downloader.client = client
+            downloader.client_tiktok = client
+            downloader.download_cover(
+                tasks,
+                "work",
+                "1",
+                item,
+                cache.joinpath("work"),
+                output.joinpath("work"),
+            )
+            await downloader.downloader_chart(
+                tasks,
+                SimpleNamespace(),
+                FakeProgress(),
+                semaphore=Semaphore(2),
+            )
+            second_run_tasks = []
+            downloader.download_cover(
+                second_run_tasks,
+                "work",
+                "1",
+                item,
+                cache.joinpath("work"),
+                output.joinpath("work"),
+            )
+            await downloader.downloader_chart(
+                second_run_tasks,
+                SimpleNamespace(),
+                FakeProgress(),
+                semaphore=Semaphore(2),
+            )
+
+        assert started == 2
+        assert second_run_tasks == []
+        assert output.joinpath("work.jpeg").read_bytes() == b"static"
+        assert output.joinpath("work_dynamic.jpeg").read_bytes() == b"dynamic"
+
+    run(download_covers())


### PR DESCRIPTION
## Summary

- preserve existing static and single-cover filenames
- use a distinct `_dynamic` stem when both cover types are downloaded
- recognize normalized `.png`, `.jpeg`, and `.webp` dynamic outputs on later runs
- continue honoring legacy dynamic-cover `.webp` files
- prevent JPEG Content-Type fallback from overwriting the static cover

## Testing

- deterministic concurrent JPEG fallback regression
- second-run skip regression
- single-cover and legacy filename compatibility coverage
- full test suite: 12 passed
- changed-file Ruff format and lint: passed

Fixes #420

## Summary by Sourcery

调整封面下载逻辑，避免静态封面和动态封面之间的文件名冲突，同时保持现有的命名行为。

Bug Fixes（错误修复）:
- 防止动态 JPEG 回退下载时覆盖已有的静态封面文件。
- 确保此前已下载的动态封面（包括旧版的 `.webp` 文件以及规范化后的 PNG/JPEG/WEBP 变体）在后续运行中能够被正确检测并跳过下载。

Enhancements（增强功能）:
- 当同时下载静态和动态封面时，引入独立的 `_dynamic` 文件名主干，以区分两类输出文件。
- 增加测试，用于覆盖并发 JPEG 回退行为、第二次运行时的跳过逻辑，以及与旧版和单一封面文件名的兼容性。

Tests（测试）:
- 添加针对封面下载命名、旧版动态封面处理以及并发 JPEG 回退行为的单元测试和集成风格测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust cover download logic to avoid filename collisions between static and dynamic covers while preserving existing naming behavior.

Bug Fixes:
- Prevent dynamic JPEG fallback downloads from overwriting existing static cover files.
- Ensure previously downloaded dynamic covers, including legacy `.webp` files and normalized PNG/JPEG/WEBP variants, are correctly detected and skipped on subsequent runs.

Enhancements:
- Introduce a distinct `_dynamic` filename stem when both static and dynamic covers are downloaded to keep outputs separate.
- Add tests to cover concurrent JPEG fallback behavior, second-run skipping, and compatibility with legacy and single-cover filenames.

Tests:
- Add unit and integration-style tests for cover download naming, legacy dynamic cover handling, and concurrent JPEG fallback behavior.

</details>