### PR TITLE
fix: 修复"从剪贴板读取 Cookie"功能失效的问题

### DIFF
--- a/src/module/cookie.py
+++ b/src/module/cookie.py
@@ -35,7 +35,7 @@ class Cookie:
         tiktok: bool = False,
     ) -> bool:
         """提取 Cookie 并写入配置文件"""
-        if cookie is None:
+        if not cookie:
             cookie: str = paste()
 
         if not self.validate_cookie_minimal(cookie):


### PR DESCRIPTION
## 问题

`从剪贴板读取 Cookie` 菜单功能无法工作：复制有效 Cookie 后按回车确认，程序始终提示`当前内容不是有效的 Cookie 内容！`。

## 原因

`TikTokDownloader.py` 中 `write_cookie_paste` 调用 `self.cookie.run(tiktok=tiktok)` 时未传 `cookie` 参数，落到默认值空字符串 `""`；而 `src/module/cookie.py` 的 `run()` 里剪贴板读取的触发条件是：

```python
if cookie is None:
    cookie: str = paste()
```

`"" is None` 恒为 False，`paste()` 永远不会被调用，空字符串直接进入 `validate_cookie_minimal` 校验并必然失败。

## 修复

条件改为 `if not cookie:`，空字符串与 `None` 均触发剪贴板读取。`手动输入 Cookie` 路径在调用前已确保 cookie 非空，不受影响。

## 验证

macOS (Python 3.12) 实测：修复前该功能 100% 复现失败；修复后复制 Cookie → 回车 → 正常提示`写入 DouYin Cookie 成功！`并写入配置文件。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug 修复：
- 修正 Cookie 输入检查逻辑，当未显式提供 Cookie 字符串时，允许从剪贴板读取，从而恢复“从剪贴板读取 Cookie”菜单功能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the cookie input check to allow reading from the clipboard when no explicit cookie string is provided, restoring the "从剪贴板读取 Cookie" menu functionality.

</details>