### PR TITLE
docs: 修复 Star 历史图表失效问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ A: 由于权限限制，您无法直接触发主仓库的 Actions。请通过 Fo
 <b>在使用本项目的代码和功能之前，请您认真考虑并接受以上免责声明。如果您对上述声明有任何疑问或不同意，请不要使用本项目的代码和功能。如果您使用了本项目的代码和功能，则视为您已完全理解并接受上述免责声明，并自愿承担使用本项目的一切风险和后果。</b>
 <h1>⭐ Star 趋势</h1>
 <p>
-<img alt="Star History Chart" src="https://api.star-history.com/svg?repos=JoeanAmier/TikTokDownloader&amp;type=Timeline"/>
+<img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=JoeanAmier/TikTokDownloader&amp;type=Timeline"/>
 </p>
 
 # 💡 项目参考

--- a/README_EN.md
+++ b/README_EN.md
@@ -419,7 +419,7 @@ repository to execute the build process
 <b>Before using the code and functionalities of this project, please carefully consider and accept the above disclaimer. If you have any questions or disagree with the statement, please do not use the code and functionalities of this project. If you use the code and functionalities of this project, it is considered that you fully understand and accept the above disclaimer, and willingly assume all risks and consequences associated with the use of this project.</b>
 <h1>⭐ Star History</h1>
 <p>
-<img alt="Star History Chart" src="https://api.star-history.com/svg?repos=JoeanAmier/TikTokDownloader&amp;type=Timeline"/>
+<img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=JoeanAmier/TikTokDownloader&amp;type=Timeline"/>
 </p>
 
 # 💡 Project References


### PR DESCRIPTION
README 中的 Star 历史图表当前已失效，无法正常显示 Star 趋势。本 PR 更新图表链接，使 Star 历史图表恢复可用，README 的英文版同步更新。

## Summary by Sourcery

文档：
- 在中文版和英文版的 README 中更新星标历史图的图片 URL，改用新的 star-history 服务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update the star history chart image URL in both Chinese and English READMEs to use the new star-history service.

</details>